### PR TITLE
@xtina-starr: Relative paths

### DIFF
--- a/components/layout/index.styl
+++ b/components/layout/index.styl
@@ -14,11 +14,11 @@
 
 @font-face
   font-family 'artsy-icons'
-  src url('/fonts/artsy-icons.eot?uo9ko')
-  src url('/fonts/artsy-icons.eot?#iefixuo9ko') format('embedded-opentype'),
-    url('/fonts/artsy-icons.woff2?uo9ko') format('woff2'),
-    url('/fonts/artsy-icons.ttf?uo9ko') format('truetype'),
-    url('/fonts/artsy-icons.woff?uo9ko') format('woff'),
-    url('/fonts/artsy-icons.svg?uo9ko#artsy-icons') format('svg')
+  src url('fonts/artsy-icons.eot?uo9ko')
+  src url('fonts/artsy-icons.eot?#iefixuo9ko') format('embedded-opentype'),
+    url('fonts/artsy-icons.woff2?uo9ko') format('woff2'),
+    url('fonts/artsy-icons.ttf?uo9ko') format('truetype'),
+    url('fonts/artsy-icons.woff?uo9ko') format('woff'),
+    url('fonts/artsy-icons.svg?uo9ko#artsy-icons') format('svg')
   font-weight normal
   font-style normal


### PR DESCRIPTION
Just a good ol' prefixed slash causing these not to show up when deployed, the lacking slash tells it to look from the current url, where without it, it was looking for `fonts` at the base hostname e.g. `https://s3.amazonaws.com`
